### PR TITLE
docs: replace REPLACE-ME placeholders with repo name

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to <REPLACE-ME>
+# Contributing to gunyah-test-vmm
 
 Hi there!
 We’re thrilled that you’d like to contribute to this project.
@@ -11,10 +11,10 @@ In general, contributors should develop on branches based off of `main` and pull
 ## Submitting a pull request
 
 1. Please read our [code of conduct](CODE-OF-CONDUCT.md) and [license](LICENSE.txt).
-1. [Fork](https://github.com/qualcomm/<REPLACE-ME>/fork) and clone the repository.
+1. [Fork](https://github.com/qualcomm/gunyah-test-vmm/fork) and clone the repository.
 
     ```bash
-    git clone https://github.com/<username>/<REPLACE-ME>.git
+    git clone https://github.com/<username>/gunyah-test-vmm.git
     ```
 
 1. Create a new branch based on `main`:
@@ -26,7 +26,7 @@ In general, contributors should develop on branches based off of `main` and pull
 1. Create an upstream `remote` to make it easier to keep your branches up-to-date:
 
     ```bash
-    git remote add upstream https://github.com/qualcomm/<REPLACE-ME>.git
+    git remote add upstream https://github.com/qualcomm/gunyah-test-vmm.git
     ```
 
 1. Make your changes, add tests, and make sure the tests still pass.
@@ -50,7 +50,7 @@ In general, contributors should develop on branches based off of `main` and pull
 
     The `-u` is shorthand for `--set-upstream`. This will set up the tracking reference so subsequent runs of `git push` or `git pull` can omit the remote and branch.
 
-1. [Submit a pull request](https://github.com/qualcomm/<REPLACE-ME>/pulls) from your branch to `main`.
+1. [Submit a pull request](https://github.com/qualcomm/gunyah-test-vmm/pulls) from your branch to `main`.
 1. Pat yourself on the back and wait for your pull request to be reviewed.
 
 ## Security Analysis of Pull Requests

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,7 +3,7 @@ How to Report a Potential Vulnerability?
 
 If you would like to report a public issue (for example, one with a released
 CVE number), please report it as a
-[GitHub issue](https://github.com/qualcomm/REPLACE-ME/issues/new).
+[GitHub issue](https://github.com/qualcomm/gunyah-test-vmm/issues/new).
 If you have a patch ready, submit it following the same procedure as any
 other patch as described in [CONTRIBUTING.md](CONTRIBUTING.md).
 


### PR DESCRIPTION
Replace all REPLACE-ME template placeholders in CONTRIBUTING.md and SECURITY.md with the actual repository name 'gunyah-test-vmm'.